### PR TITLE
[FIX]add layout for contact and services page with responsiveness

### DIFF
--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -1,0 +1,215 @@
+import React from 'react';
+
+// axios
+// import axios from 'axios';
+// import { inquiryURL } from '../api/PublicAPI.jsx';
+
+import { GoogleMap, withScriptjs, withGoogleMap, Marker } from 'react-google-maps';
+
+import { CallIcon } from '../subComponents/AllSvg.jsx';
+import { MailIcon } from '../subComponents/AllSvg.jsx';
+import googleMapStyle from '../subComponents/googleMapStyle.jsx';
+
+const Map = () => {
+  return (
+    <GoogleMap
+      defaultZoom={15}
+      defaultCenter={{ lat: 14.578400, lng: 120.983240 }}
+      defaultOptions={{ styles: googleMapStyle }}
+    >
+      < Marker position={{ lat: 14.578400, lng: 120.983240 }} />
+    </GoogleMap>
+
+  )
+}
+
+const WrappedMap = withScriptjs(withGoogleMap(Map));
+
+const Contact = () => {
+
+  /* State Management */
+  //const [getInquiries, setGetInquiries] = useState([]);
+
+  // Add Inquiry State
+  // const [fullname, setFullName] = useState('');
+  // const [email, setEmail] = useState('');
+  // const [phone, setPhone] = useState(0);
+  // const [message, setMessage] = useState('');
+
+  // Status
+  // const [status, setStatus] = useState('Adding Inquiry');
+
+
+  // useEffect(() => {
+  //   axios.get(inquiryURL)
+  //     .then(res => {
+  //       console.log(res.data.data)
+  //       setGetInquiries(res.data.data)
+  //     })
+  //     .catch(err => {
+  //       console.log(err)
+  //     })
+  // }, []);
+
+  // const handleAddInquiry = (e) => {
+  //   e.preventDefault();
+  //   const addInquiry = inquiryURL;
+
+  //   setStatus('Adding Inquiry');
+
+  //   return axios.post(
+  //     addInquiry,
+  //     { fullname: fullname, email: email, phone: phone, message: message }
+  //   )
+  // }
+
+  return (
+    <div className="contact__container" id="contact">
+      <div className="contact__container--section h-auto p-4 flex flex-col items-center justify-center">
+        <div className="contact__container--header w-11/12">
+          <h2 className="text-5xl text-center font-bold lg:text-5xl md:text-5xl sm:text-4xl custom:text-xl">
+            Contact {" "}
+            <span className="text-green-800">Details</span>
+          </h2>
+        </div><br />
+        <div className="contact__container--body w-11/12">
+          {/* GOOGLE MAP START */}
+          <div className="contact__google_map">
+            <WrappedMap
+              googleMapURL={`https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=geometry,drawing,places&key=AIzaSyBCoifrIuftYlU5_KbaZ_-qoqtrjT7Ckws`}
+              loadingElement={<div style={{ height: `100%` }} />}
+              containerElement={<div style={{ height: `400px` }} />}
+              mapElement={<div style={{ height: `100%` }} />}
+            />
+          </div>
+          {/* GOOGLE MAP END */}
+          {/* CONTACT INFORMATION START */}
+          <div className="contact__information  bg-slate-300">
+            <div className="contact__info--header w-full py-4 px-12">
+              <span className="text-3xl">JNCE Medical & Diagnostic Clinic</span>
+            </div><br />
+            <div className="contact__info--body px-12 flex justify-between sm:justify-center sm:flex-col custom:justify-center custom:flex-col">
+              <div className="max-w-sm">
+                <div className="px-6 py-4">
+                  <div className="font-bold text-xl text-green-800 mb-2">Clinic hours</div>
+                  <div className="text-gray-700 text-base">
+                    Visitors are limited during COVID-19. Find out
+                  </div>
+                  <div className="text-gray-700 text-base">
+                    more about visitors and visiting hours
+                  </div>
+                  <div className="text-gray-700 text-base">
+                    via inquiring us.
+                  </div>
+                  <div className="text-gray-700 text-base">
+                    &nbsp;
+                  </div>
+                  <div className="text-gray-700 text-base">
+                    &nbsp;
+                  </div>
+                  <div className="text-gray-700 text-base">
+                    &nbsp;
+                  </div>
+                </div>
+              </div>
+              <div className="max-w-sm">
+                <div className="px-6 py-4">
+                  <div className="font-bold text-xl text-green-800 mb-2">Address</div>
+                  <div className="text-gray-700 text-base">
+                    G/F CDC Bldg. 1195
+                  </div>
+                  <div className="text-gray-700 text-base">
+                    Ma. Orosa St.
+                  </div>
+                  <div className="text-gray-700 text-base">
+                    Ermita Manila
+                  </div>
+                  <div className="text-gray-700 text-base">
+                    Philippines
+                  </div>
+                  <div className="text-gray-700 text-base">
+                    &nbsp;
+                  </div>
+                  <div className="text-gray-700 text-base">
+                    &nbsp;
+                  </div>
+                </div>
+              </div>
+              <div className="max-w-sm">
+                <div className="px-6 py-4">
+                  <div className="font-bold text-xl text-green-800 mb-2">Contact</div>
+                  <div className="text-gray-700 text-base">
+                    <span className="font-bold">Tel. no.:</span>
+                  </div>
+                  <div className="text-gray-700 text-base flex gap-2">
+                    <CallIcon className="h-7 w-7" aria-hidden="true" /><span>(02) 8 518-5156 / (02) 8 310-5206</span>
+                  </div>
+                  <div className="text-gray-700 text-base">
+                    <span className="font-bold">Cell. no.:</span>
+                  </div>
+                  <div className="text-gray-700 text-base flex gap-2">
+                    <CallIcon className="h-7 w-7" aria-hidden="true" /><span>(+63)947-584-2888</span>
+                  </div>
+                  <div className="text-gray-700 text-base">
+                    <span className="font-bold">Email:</span>
+                  </div>
+                  <div className="text-gray-700 text-base flex gap-2">
+                    <MailIcon className="h-7 w-7" aria-hidden="true" /><span>jnceclinic@yahoo.com</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          {/* CONTACT INFORMATION END */}
+          <br />
+          {/* CONTACT INQUIRY FORM START */}
+          <div className="contact__form bg-slate-300 border-t-8 border-green-800 py-4 px-12 flex flex-col">
+            <span className="text-green-800 text-3xl">Online Inquiry form</span><br />
+            <span className="font-bold">Feedback from this form is not monitored outside of normal business hours. If you have a medical or mental health emergency, please contact us on our hotlines.</span>
+            <span>We are unable to provide medical advice or answer individual questions about treatment - these issues should be raised with your doctor.</span>
+            <br />
+            <form>
+              <div className="contact__form--container flex justify-evenly sm:flex-col sm:justify-center custom:flex-col custom:justify-center">
+                <div className="w-1/2 px-2 sm:w-full custom:w-full">
+                  <div className="text-gray-700 mb-4 w-full">
+                    <label className="block mb-1 text-green-600 font-bold" for="name">Name</label>
+                    <input className="w-full h-10 px-3 py-6 text-base placeholder-gray-600 border rounded-lg focus:shadow-outline" type="text" id="name" placeholder='full name' required />
+                  </div>
+                  <div className="text-gray-700 mb-4 w-full">
+                    <label className="block mb-1 text-green-600 font-bold" for="email">Your email</label>
+                    <input className="w-full h-10 px-3 py-6 text-base placeholder-gray-600 border rounded-lg focus:shadow-outline" type="email" id="email" placeholder="valid email" required />
+                  </div>
+                  <div className="text-gray-700 mb-4 w-full">
+                    <label className="block mb-1 text-green-600 font-bold" for="phone">Phone</label>
+                    <input className="w-full h-10 px-3 py-6 text-base placeholder-gray-600 border rounded-lg focus:shadow-outline" type="phone" id="phone" placeholder='contact number' required />
+                  </div>
+                </div>
+                <div className="w-1/2 px-2 sm:w-full custom:w-full">
+                  <div className="text-gray-700 mb-4 w-full">
+                    <label className="block mb-1 text-green-600 font-bold" for="message">Message</label>
+                    <textarea id="message" className="w-full h-[240px] px-3 py-2 text-base text-gray-700 placeholder-gray-600 border rounded-lg focus:shadow-outline" placeholder="Leave your concern......" required></textarea>
+                  </div>
+                  <div className="w-full">
+                    <button type="submit" className="relative w-full sm:w-full custom:w-full inline-flex items-center justify-start py-3 pl-4 pr-12 overflow-hidden font-semibold text-indigo-600 transition-all duration-150 ease-in-out rounded hover:pl-10 hover:pr-6 bg-gray-50 group">
+                      <span className="absolute bottom-0 left-0 w-full h-1 transition-all duration-150 ease-in-out bg-indigo-600 group-hover:h-full"></span>
+                      <span className="absolute right-0 pr-4 duration-200 ease-out group-hover:translate-x-12">
+                        <svg className="w-5 h-5 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"></path></svg>
+                      </span>
+                      <span className="absolute left-0 pl-2.5 -translate-x-12 group-hover:translate-x-0 ease-out duration-200">
+                        <svg className="w-5 h-5 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"></path></svg>
+                      </span>
+                      <span className="relative w-full text-center transition-colors duration-200 ease-in-out group-hover:text-white">Submit your Inquiry</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </form>
+          </div>
+          {/* CONTACT INQUIRY FORM END */}
+        </div >
+      </div >
+    </div >
+  )
+}
+
+export default Contact;

--- a/src/components/Services.jsx
+++ b/src/components/Services.jsx
@@ -1,0 +1,162 @@
+import React, { useEffect } from 'react';
+
+import { LazyLoadImage } from 'react-lazy-load-image-component';
+
+// Framer Motion
+import { useInView } from 'react-intersection-observer';
+import { motion, useAnimation } from 'framer-motion';
+
+// SVG
+import 'boxicons';
+
+const Services = () => {
+  const { ref, inView } = useInView({
+    threshold: 0.2
+  });
+
+  const animationLeft = useAnimation();
+
+  useEffect(() => {
+    if (inView) {
+      animationLeft.start({
+        x: 0,
+        opacity: 1,
+        transition: {
+          type: 'spring', duration: 1, bounce: 0.3
+        }
+      });
+    }
+
+    if (!inView) {
+      animationLeft.start({
+        x: '-100px',
+        opacity: 0
+      });
+    }
+  })
+
+  return (
+    <div className="services__container" id="services">
+      <div className="services__container--section h-auto p-4 flex flex-col items-center justify-center">
+        <div className="services__container--header text-right w-11/12">
+          <h2 className="text-5xl font-bold lg:text-5xl md:text-5xl sm:text-4xl custom:text-2xl">
+            Our {" "}
+            <span className="text-green-800">Services </span>
+          </h2>
+        </div>
+
+        <br /><br />
+
+        <div className="services__container--section--img bg-green-800 w-full h-auto">
+          <div className="flex items-center justify-center gap-20 mb-10">
+
+            <div className="">
+              <div className="service__container--img h-40 text-white">
+                Image 1
+              </div>
+              <div className="text-white">
+                Image 2
+              </div>
+            </div>
+
+            <div className="">
+              <div className="service__container--img h-48 mt-8 text-white">
+                Image 3
+              </div>
+              <div className="text-white">
+                Image 4
+              </div>
+            </div>
+
+            <div className="">
+              <div className="service__container--img h-56 mt-16 text-white">
+                Image 5
+              </div>
+              <div className="text-white">
+                Image 6
+              </div>
+            </div>
+
+          </div>
+        </div>
+
+        <br /><br />
+
+        {/* Service Title */}
+        <h2 className="text-4xl font-bold custom:text-lg md:text-2xl xl:text-4xl">What does JNCE Medical Clinic Offers?</h2>
+
+        <br /><br />
+
+        <div className="service__container--body1 w-11/12 flex flex-col justify-center lg:block">
+
+          <div ref={ref} className="service__container--num1 flex items-center justify-around sm:flex-col sm:justify-center custom:flex-col custom:justify-center custom:gap-5 mb-10 xl:gap-0">
+
+            {/* Service Descriptions */}
+            <div className="flex flex-col sm:order-2 sm:pt-12 custom:order-2 custom:pt-12">
+
+              <motion.div animate={animationLeft} className="flex gap-5 mb-4">
+                <box-icon name='hand-right' type='solid' color='#b2856a' size='md'></box-icon>
+                <h1 className="text-xl font-medium md:text-xl sm:text-3xl lg:text-2xl xl:text-2xl 2xl:text-2xl custom:text-lg">Laboratory Facility</h1>
+              </motion.div>
+
+              <motion.div animate={animationLeft} className="flex gap-5 mb-4">
+                <box-icon name='hand-right' type='solid' color='#b2856a' size='md'></box-icon>
+                <h1 animate={animationLeft} className="text-xl font-medium md:text-xl sm:text-3xl lg:text-2xl xl:text-2xl 2xl:text-2xl custom:text-lg">Medical Consultation</h1>
+              </motion.div>
+
+              <motion.div animate={animationLeft} className="flex gap-5 mb-4">
+                <box-icon name='hand-right' type='solid' color='#b2856a' size='md'></box-icon>
+                <h1 animate={animationLeft} className="text-xl font-medium md:text-xl sm:text-3xl lg:text-2xl xl:text-2xl 2xl:text-2xl custom:text-lg">Electrocardiogram</h1>
+              </motion.div>
+
+              <motion.div animate={animationLeft} className="flex gap-5 mb-4">
+                <box-icon name='hand-right' type='solid' color='#b2856a' size='md'></box-icon>
+                <h1 animate={animationLeft} className="text-xl font-medium md:text-xl sm:text-3xl lg:text-2xl xl:text-2xl 2xl:text-2xl custom:text-lg">Dental Services</h1>
+              </motion.div>
+
+              <motion.div animate={animationLeft} className="flex gap-5 mb-4">
+                <box-icon name='hand-right' type='solid' color='#b2856a' size='md'></box-icon>
+                <h1 animate={animationLeft} className="text-xl font-medium md:text-xl sm:text-3xl lg:text-2xl xl:text-2xl 2xl:text-2xl custom:text-lg">Pre Employment Medical Examination</h1>
+              </motion.div>
+
+              <motion.div animate={animationLeft} className="flex gap-5 mb-4">
+                <box-icon name='hand-right' type='solid' color='#b2856a' size='md'></box-icon>
+                <h1 animate={animationLeft} className="text-xl font-medium md:text-xl sm:text-3xl lg:text-2xl xl:text-2xl 2xl:text-2xl custom:text-lg">Seafarer's Medical Examination</h1>
+              </motion.div>
+
+              <motion.div animate={animationLeft} className="flex gap-5 mb-4">
+                <box-icon name='hand-right' type='solid' color='#b2856a' size='md'></box-icon>
+                <h1 animate={animationLeft} className="text-xl font-medium md:text-xl sm:text-3xl lg:text-2xl xl:text-2xl 2xl:text-2xl custom:text-lg">Ultrasound</h1>
+              </motion.div>
+
+              <motion.div animate={animationLeft} className="flex gap-4">
+                <box-icon name='hand-right' type='solid' color='#b2856a' size='md'></box-icon>
+                <div className="flex flex-col">    
+                  <h1 animate={animationLeft} className="text-xl font-medium md:text-xl sm:text-3xl lg:text-2xl xl:text-2xl 2xl:text-2xl custom:text-lg">RTPCR Testing</h1>
+                  <a href="https://alliedmolecular.com/home/index" target="_blank">
+                    <small><span className="text-base text-blue-600 hover:text-green-400 sm:text-sm custom:text-sm">(in Partnership with Allied Molecular Laboratory)</span></small>
+                  </a>
+                </div>
+              </motion.div>
+
+            </div>
+
+            {/* Service Image */}
+            <div className="service__container--img sm:order-1 custom:order-1">
+              <LazyLoadImage
+                className="w-11/12 md:w-11/12 sm:w-full custom:w-90"
+                alt="Lab Image"
+                src={'https://images.unsplash.com/photo-1614935151651-0bea6508db6b?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=700&q=144'}
+              />
+            </div>
+
+          </div>
+
+        </div>
+
+      </div>
+    </div>
+  )
+}
+
+export default Services;

--- a/src/pages/Landing.js
+++ b/src/pages/Landing.js
@@ -3,8 +3,8 @@ import React from 'react'
 // Components
 import Home from '../components/Home';
 import About from '../components/About';
-// import Services from '../components/Services';
-// import Contact from '../components/Contact';
+import Services from '../components/Services';
+import Contact from '../components/Contact';
 import Footer from '../components/Footer';
 import Header from '../components/Header';
 
@@ -14,9 +14,8 @@ const Landing = () => {
       <Header />
       <Home />
       <About />
-      {/* <Services />
+      <Services />
       <Contact />
-       */}
       <Footer />
     </>
   )


### PR DESCRIPTION
## Summary
- Add layout for contact and services page.

## Services page screenshots
![services image layout](https://user-images.githubusercontent.com/88585596/160051529-870315ff-f48c-46f7-8e9f-e890adf53e1d.JPG)
![service offers layout](https://user-images.githubusercontent.com/88585596/160051542-f600dfe0-a8fe-447b-a082-b67b9c40ede1.JPG)

## Contact page screenshots
![contact page google map](https://user-images.githubusercontent.com/88585596/160051913-c24df387-19a8-48ea-b08c-05ef9db470d1.JPG)
![contact information](https://user-images.githubusercontent.com/88585596/160051948-5a27e6e2-2492-43e4-99ac-e447bf1c4c96.JPG)
![contact page form](https://user-images.githubusercontent.com/88585596/160051984-2503d9cd-08ad-459e-89fe-5f6a00dc416c.JPG)

